### PR TITLE
Add option to specify the catalog name and the location of the catalo…

### DIFF
--- a/catalog-source-template
+++ b/catalog-source-template
@@ -1,7 +1,7 @@
 apiVersion: operators.coreos.com/v1alpha1
 kind: CatalogSource
 metadata:
-  name: custom-redhat-operators
+  name: {{ CatalogName }}
   namespace: openshift-marketplace
 spec:
   displayName: Red Hat Operators

--- a/mirror-operator-catalogue.py
+++ b/mirror-operator-catalogue.py
@@ -86,7 +86,16 @@ parser.add_argument(
 parser.add_argument(
     "--oc-cli-path",
     default="oc",
-    help="Full path of oc cli")    
+    help="Full path of oc cli")
+parser.add_argument(
+    "--custom-operator-catalog-image-url",
+    default="",
+    help="custom operator catalog image url in your registry")
+parser.add_argument(
+    "--custom-operator-catalog-name",
+    default="custom-redhat-operators",
+    help="custom operator catalog name")
+
 args = parser.parse_args()
 
 # Global Variables
@@ -121,6 +130,9 @@ custom_redhat_operators_catalog_image_url = args.registry_catalog + "/custom-" +
 oc_cli_path=args.oc_cli_path
 # This will be removed once we hit 4.7 This is to get the latest version of opm cli
 temp_redhat_operators_catalog_image_url = "registry.redhat.io/redhat/redhat-operator-index:v4.7"
+
+if args.custom_operator_catalog_image_url:
+  custom_redhat_operators_catalog_image_url = args.registry_catalog + "/" + args.custom_operator_catalog_image_url + operator_index_version
 
 
 def main():
@@ -486,7 +498,7 @@ def GetSourceToMirrorMapping(images):
 def CreateCatalogSourceYaml(image_url):
   with open(catalog_source_template_file, 'r') as f:
     templateFile = Template(f.read())
-  content = templateFile.render(CatalogSource=image_url)
+  content = templateFile.render(CatalogSource=image_url,CatalogName=args.custom_operator_catalog_name)
   with open(catalog_source_output_file, "w") as f:
     f.write(content)
 


### PR DESCRIPTION
Add 2 options to control the naming of the catalog image.

- One option allows for naming the catalog in the yaml that will deploy the operator catalog into the cluster
- The other option allows for setting where the catalog image is mirrored to (named) in the registry

This PR supports creating smaller catalogs, perhaps even 1 for each operator, that will not overlap images in the registry or catalog names in the cluster.