### PR TITLE
Update readme to reference correct filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ For a full list of operators that work offline please see link below
     --authfile /var/run/containers/0/auth.json \
     --registry-olm local_registry_url:5000 \
     --registry-catalog local_registry_url:5000 \
-    --operator-file ./offline-operator-list \
+    --operator-file ./offline_operator_list \
     --icsp-scope=namespace
     ```
 


### PR DESCRIPTION
Within the README, the offline operator list is referenced with hyphens instead of underscores like is used within this repo. This PR fixes the README example script run to use underscores instead.